### PR TITLE
Add support for exiting with an exit code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "barnacle"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "barnacle"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Bert JW Regeer <xistence@0x58.com>"]
 license = "ISC"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,8 +13,12 @@ pub struct Cli {
     pub output: PathBuf,
 
     /// The command + arguments to execute once template is rendered
-    #[arg(required(true))]
+    #[arg(group = "command_or_exit", required(true))]
     pub command: Vec<String>,
+
+    /// Exit with error code, exclusive with a command to exeute
+    #[arg(short, long, group = "command_or_exit", required(true))]
+    pub exit: Option<u8>,
 
     /// Turn debugging information on
     #[arg(short, long, action = clap::ArgAction::Count)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,5 +40,11 @@ fn main() {
 
     fs::write(&matches.output, output).expect("Failed to write output file");
 
+    // If we have an exit code, use it
+    if let Some(exit) = matches.exit {
+        std::process::exit(exit.into());
+    }
+
+    // Otherwise we execute the command provided on the CLI
     exec(&matches.command);
 }


### PR DESCRIPTION
This allows barnacle to be used as an init container or some other process that simply requires barnacle to render the configuration file but not execute another process.

It is mutually exclusive with providing a command to barnacle

Closes #5 